### PR TITLE
chore(ci): let Renovate keep dependencies current and test pull requests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,76 @@
+// Configuration for the Mend Renovate GitHub App (https://docs.renovatebot.com).
+//
+// The app must be installed for the `edutap-eu` organisation (or at least for
+// this repository) — without it, this file has no effect. Renovate then opens
+// a "Dependency Dashboard" issue listing every pending update, and raises pull
+// requests according to the schedule below. There is no workflow file for this:
+// the hosted app runs Renovate on its own infrastructure.
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  extends: [
+    "config:recommended",
+    // Keep the dashboard issue up to date even when no PR is open, so pending
+    // updates stay visible instead of piling up unnoticed.
+    ":dependencyDashboard",
+    // The repository uses Conventional Commits; Renovate should too.
+    ":semanticCommits",
+    // Security fixes bypass the schedule and are raised immediately.
+    ":enableVulnerabilityAlertsWithLabel(security)",
+  ],
+
+  timezone: "Europe/Berlin",
+
+  // One batched run per week keeps the noise low; the dashboard issue shows
+  // everything that is waiting in between.
+  schedule: ["before 06:00 on monday"],
+
+  labels: ["dependencies"],
+  prConcurrentLimit: 5,
+  prHourlyLimit: 0,
+
+  // Give a freshly published release a few days to be pulled if it is broken.
+  minimumReleaseAge: "3 days",
+
+  // Refresh package-lock.json transitively once a month, so indirect
+  // dependencies do not silently rot between direct-dependency updates.
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["before 06:00 on the first monday of the month"],
+  },
+
+  packageRules: [
+    {
+      // Astro and its official integrations are released in lockstep and are
+      // only meaningful to review together.
+      groupName: "Astro",
+      matchPackageNames: ["astro", "@astrojs/**"],
+    },
+    {
+      groupName: "Tailwind CSS",
+      matchPackageNames: ["tailwindcss", "@tailwindcss/**"],
+    },
+    {
+      groupName: "Sentry",
+      matchPackageNames: ["@sentry/**"],
+    },
+    {
+      // Tooling that cannot affect the published site: batch it into a single
+      // PR instead of one per package.
+      groupName: "dev tooling (non-major)",
+      matchDepTypes: ["devDependencies"],
+      matchUpdateTypes: ["minor", "patch"],
+    },
+    {
+      groupName: "GitHub Actions",
+      matchManagers: ["github-actions"],
+    },
+    {
+      // The Node version in `.nvmrc` pins the runtime used locally and in CI.
+      // Only follow the LTS line — see https://endoflife.date/nodejs.
+      matchManagers: ["nvm"],
+      matchPackageNames: ["node"],
+      allowedVersions: "/^(\\d*[02468])$/",
+    },
+  ],
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,9 +34,12 @@
 
   // Refresh package-lock.json transitively once a month, so indirect
   // dependencies do not silently rot between direct-dependency updates.
+  // "on the first monday of the month" is not parseable by Renovate's
+  // schedule syntax and made the whole configuration invalid; the day of the
+  // month is. Verified with `npx --package renovate renovate-config-validator`.
   lockFileMaintenance: {
     enabled: true,
-    schedule: ["before 06:00 on the first monday of the month"],
+    schedule: ["before 06:00 on the first day of the month"],
   },
 
   packageRules: [

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
         run: npm ci
       - name: Type-check content and components
         run: npm run check
+      - name: Check formatting
+        run: npm run format:check
       - name: Run tests
         # `pretest` builds the site, so a broken build fails here too.
         run: npm run test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,12 @@ on:
 permissions:
   contents: read
 
+# Keyed on the branch, not on `github.ref`: a branch with an open pull request
+# fires both triggers, and `github.ref` differs between them
+# (refs/pull/N/merge vs refs/heads/<branch>), so the two runs would not cancel
+# each other and every push would be built twice.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: Test Website
+
+# The Pages workflow only runs on pushes to `main`, i.e. after a merge. This
+# workflow gives every pull request — including the ones Renovate opens for
+# dependency updates — the same check beforehand.
+on:
+  pull_request:
+  push:
+    branches-ignore: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Type-check content and components
+        run: npm run check
+      - name: Run tests
+        # `pretest` builds the site, so a broken build fails here too.
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -114,15 +114,18 @@ once the [Mend Renovate app](https://github.com/apps/renovate) is installed for 
 this repository)**. Until then, `.github/renovate.json5` is inert.
 
 Updates are grouped so that packages which are only meaningful together end up in one pull request: Astro and its
-integrations, Tailwind CSS, Sentry, all non-major dev tooling, and GitHub Actions. Every pull request runs the same
-test suite as a push to `main`, so a broken update fails before it can be merged. Node in `.nvmrc` is only offered
-even-numbered (LTS) releases — see <https://endoflife.date/nodejs>.
+integrations, Tailwind CSS, Sentry, all non-major dev tooling, and GitHub Actions. Every pull request is
+type-checked, format-checked and tested by the "Test Website" workflow (see below), so a broken update fails
+before it can be merged. Node in `.nvmrc` is only offered even-numbered (LTS) releases —
+see <https://endoflife.date/nodejs>.
 
 ## Deployment
 
 Every pull request and every push to a branch other than `main` runs the "Test Website" workflow
-(`.github/workflows/ci.yaml`): it type-checks the project (`npm run check`) and runs the test suite (which builds
-the site as part of its `pretest` step).
+(`.github/workflows/ci.yaml`): it type-checks the project (`npm run check`), verifies formatting
+(`npm run format:check`) and runs the test suite (which builds the site as part of its `pretest` step). The deploy
+workflow below runs the tests but not those two checks, since a change reaching `main` has already passed them
+here.
 
 Pushing to `main` triggers the "Deploy static content to Pages" GitHub Actions workflow
 (`.github/workflows/pages.yaml`), which installs dependencies, runs the test suite (which builds the site as part

--- a/README.md
+++ b/README.md
@@ -102,7 +102,27 @@ short: "This is my first blog post" # short description shown on the news index 
 ---
 ```
 
+## Dependency updates
+
+Dependency updates are raised by [Renovate](https://docs.renovatebot.com), configured in
+[`.github/renovate.json5`](.github/renovate.json5). Renovate keeps an open "Dependency Dashboard" issue listing
+every pending update, and opens grouped pull requests once a week (Monday morning, Europe/Berlin). Security
+fixes ignore that schedule and are raised immediately, labelled `security`.
+
+Renovate runs as a hosted GitHub App, not as a workflow in this repository — **the configuration only takes effect
+once the [Mend Renovate app](https://github.com/apps/renovate) is installed for the organisation (or at least for
+this repository)**. Until then, `.github/renovate.json5` is inert.
+
+Updates are grouped so that packages which are only meaningful together end up in one pull request: Astro and its
+integrations, Tailwind CSS, Sentry, all non-major dev tooling, and GitHub Actions. Every pull request runs the same
+test suite as a push to `main`, so a broken update fails before it can be merged. Node in `.nvmrc` is only offered
+even-numbered (LTS) releases — see <https://endoflife.date/nodejs>.
+
 ## Deployment
+
+Every pull request and every push to a branch other than `main` runs the "Test Website" workflow
+(`.github/workflows/ci.yaml`): it type-checks the project (`npm run check`) and runs the test suite (which builds
+the site as part of its `pretest` step).
 
 Pushing to `main` triggers the "Deploy static content to Pages" GitHub Actions workflow
 (`.github/workflows/pages.yaml`), which installs dependencies, runs the test suite (which builds the site as part


### PR DESCRIPTION
## Summary

Dependencies were updated by hand, and nothing checked a pull request before it was merged. This adds both halves of that: automated update proposals, and a build that judges them.

- **`.github/renovate.json5`** — Renovate opens grouped update pull requests once a week (Monday morning, Europe/Berlin) and keeps an open "Dependency Dashboard" issue listing everything pending in between. Security fixes ignore the schedule and are raised immediately with a `security` label. Updates are grouped so packages that are only meaningful together arrive in one pull request: Astro and its integrations, Tailwind CSS, Sentry, all non-major dev tooling, and GitHub Actions. `minimumReleaseAge: 3 days` lets a broken release be pulled before we adopt it, and monthly lockfile maintenance keeps indirect dependencies from rotting between direct updates. Node in `.nvmrc` is only offered even-numbered (LTS) releases, per <https://endoflife.date/nodejs>.
- **`.github/workflows/ci.yaml`** — the only workflow so far runs on pushes to `main`, i.e. *after* a merge, so a dependency update would have been merged without ever being built or tested. "Test Website" now type-checks, format-checks and tests every pull request and every push outside `main`. Renovate's pull requests therefore arrive with a verdict attached; so does every pull request that follows.

## Action required before this has any effect

Renovate here is configuration only — it runs as the hosted Mend GitHub App, not as a workflow in this repository. **`.github/renovate.json5` stays inert until the [Renovate app](https://github.com/apps/renovate) is installed for the `edutap-eu` organisation** (or at least for this repository). The CI workflow works immediately and independently.

## Tests

- `make lint` → `astro check`: 0 errors, 0 warnings, 0 hints; `prettier --check .`: clean
- `npm run test` → 83 passed (10 files), including the production build via `pretest`
- The workflow itself first runs on this pull request.

## Risks

- The weekly schedule and the grouping are judgement calls, not settled facts; both are one edit away if the pull request volume turns out wrong.
- `ci.yaml` uses `node-version-file: .nvmrc` rather than the hard-coded `24` in `pages.yaml`, so CI follows the repository's Node version by itself. Worth aligning `pages.yaml` the same way in a later change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)