### PR TITLE
ci: hold a direct push to main to the same standard as a pull request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".nvmrc"
           cache: npm

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -28,14 +28,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 24
+          # Follows .nvmrc rather than repeating the version here, where it
+          # would silently drift once .nvmrc is bumped.
+          node-version-file: ".nvmrc"
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Type-check content and components
+        run: npm run check
+      - name: Check formatting
+        run: npm run format:check
       - name: Run tests
         run: npm run test
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ see <https://endoflife.date/nodejs>.
 Every pull request and every push to a branch other than `main` runs the "Test Website" workflow
 (`.github/workflows/ci.yaml`): it type-checks the project (`npm run check`), verifies formatting
 (`npm run format:check`) and runs the test suite (which builds the site as part of its `pretest` step). The deploy
-workflow below runs the tests but not those two checks, since a change reaching `main` has already passed them
-here.
+workflow below runs the same three, so a direct push to `main` is held to the same standard.
 
 Pushing to `main` triggers the "Deploy static content to Pages" GitHub Actions workflow
-(`.github/workflows/pages.yaml`), which installs dependencies, runs the test suite (which builds the site as part
-of its `pretest` step), and publishes `dist/` to GitHub Pages.
+(`.github/workflows/pages.yaml`), which runs the same checks as CI — type check, format check and the test suite,
+which builds the site as part of its `pretest` step — and then publishes `dist/` to GitHub Pages. It repeats the
+checks rather than trusting the pull request, because `main` can also be pushed to directly.


### PR DESCRIPTION
## Summary

Follow-up to the Copilot review on #7. Its README comment ended with *"unless `pages.yaml` is updated to match"* — the wording was corrected in #7, but the workflow was not, so the discrepancy the comment described was still real.

- **`pages.yaml` runs the same three steps as CI.** A pull request was type-checked, format-checked and tested; a push straight to `main` only ran the tests and then deployed. `main` does receive direct pushes in this repository, so the deploy workflow now runs `npm run check` and `npm run format:check` as well. It repeats work an approved pull request already did — that costs seconds and covers the path that has no pull request at all.
- **Node version comes from `.nvmrc`.** `pages.yaml` pinned a literal `24` next to a `.nvmrc` saying the same thing: two places to update, one of which Renovate maintains. It now uses `node-version-file`, like `ci.yaml`.
- **`actions/checkout` and `actions/setup-node` v4 → v7.** GitHub annotates every run of the v4 actions with a Node 20 deprecation notice and already forces them onto Node 24.

## Why the version jump is safe here

Checked rather than assumed, since v4 → v7 crosses three majors:

- `setup-node` v5 introduces automatic caching *when `package.json` has a `packageManager` field*. This one does not, and `cache: npm` is set explicitly. v6 limits that automatic caching to npm, which is what we use.
- `checkout` v6 changes where credentials are persisted; v7 blocks fork checkouts for `pull_request_target` and `workflow_run`. Neither trigger is used here.

## Deliberately not changed

`actions/upload-pages-artifact` (v3, latest v5) and `actions/deploy-pages` (v4, latest v5) stay as they are. v4 of the upload action stops including dotfiles in the artifact, and `deploy-pages` v4 already documents an `actions: read` permission requirement — a broken deploy is not something to discover after a merge. They deserve their own change, with the resulting deployment watched. Once the Renovate app is installed it will propose them in the "GitHub Actions" group anyway.

## Tests

- `make lint` → `astro check`: 0 errors, 0 warnings, 0 hints; `prettier --check .`: clean
- `npm run test` → 97 passed (10 files)
- `ci.yaml` validates itself on this pull request. `pages.yaml` only runs on `main`, so its first real run is the merge — the change to it is three added steps and two version bumps, and a failed deploy leaves the currently published site untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)